### PR TITLE
allow float with one decimal place for finer quality control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.log
 .vscode
+gui.ini

--- a/dashcamcleaner/cli.py
+++ b/dashcamcleaner/cli.py
@@ -128,9 +128,9 @@ def parse_arguments():
         "--quality",
         metavar="[1, 10]",
         required=False,
-        help="quality of the resulting video. higher = better, default: 10",
-        type=int,
-        choices=range(1, 11),
+        help="quality of the resulting video. higher = better, default: 10. conversion to crf: ⌊(1-q/10)*51⌋",
+        type=float,
+        choices=[round(x / 10, ndigits=2) for x in range(10, 101)],
         default=10,
     )
     optional.add_argument(


### PR DESCRIPTION
obviously not all floats will result in differing crf values, that does not matter.

as [mentioned](https://github.com/tfaehse/DashcamCleaner/pull/26#issuecomment-1203161008) in #26 crf values larger than 45 are not possible due to the limit check in imageio.

here is a conversion chart:
crf | quality
:--: | :--:
0 | 10
1 | 9,8
2 | 9,6
3 | 9,4
4 | 9,2
5 | 9
6 | 8,8
7 | 8,6
8 | 8,4
9 | 8,2
10 | 8
11 | 7,8
12 | 7,6
13 | 7,4
14 | 7,2
15 | 7
16 | 6,8
17 | 6,6
18 | 6,4
19 | 6,2
20 | 6
21 | 5,8
22 | 5,6
23 | 5,4
24 | 5,2
25 | 5
26 | 4,9
27 | 4,7
28 | 4,5
29 | 4,3
30 | 4,1
31 | 3,9
32 | 3,7
33 | 3,5
34 | 3,3
35 | 3,1
36 | 2,9
37 | 2,7
38 | 2,5
39 | 2,3
40 | 2,1
41 | 1,9
42 | 1,7
43 | 1,5
44 | 1,3
45 | 1,1

