### PR TITLE
fixed image returned even if (empty) mask expected

### DIFF
--- a/dashcamcleaner/src/blurrer.py
+++ b/dashcamcleaner/src/blurrer.py
@@ -61,10 +61,10 @@ class VideoBlurrer:
             scaled_detection.age = 0
             self.detections.append(scaled_detection)
 
-        if len(self.detections) < 1 and not (export_mask or export_colored_mask):
+        if len(self.detections) < 1:
             # there are no detections for this frame, leave early
             if not (export_mask or export_colored_mask): 
-                # if not mask export return the same input-frame
+                # if not mask export, return the same input-frame
                 return frame
             else:
                 # if mask export, return empty mask

--- a/dashcamcleaner/src/blurrer.py
+++ b/dashcamcleaner/src/blurrer.py
@@ -63,12 +63,12 @@ class VideoBlurrer:
 
         if len(self.detections) < 1:
             # there are no detections for this frame, leave early
-            if not (export_mask or export_colored_mask): 
-                # if not mask export, return the same input-frame
-                return frame
-            else:
+            if export_mask or export_colored_mask: 
                 # if mask export, return empty mask
                 return np.full((frame.shape[0], frame.shape[1], 3), 0, dtype=np.uint8)
+            else:
+                # if not mask export, return the input-frame
+                return frame
 
         # convert to float, since the mask needs to be in range [0, 1] and in float
         frame = np.float64(frame)

--- a/dashcamcleaner/src/blurrer.py
+++ b/dashcamcleaner/src/blurrer.py
@@ -61,9 +61,14 @@ class VideoBlurrer:
             scaled_detection.age = 0
             self.detections.append(scaled_detection)
 
-        if len(self.detections) < 1:
-            # there are no detections for this frame, leave early and return the same input-frame
-            return frame
+        if len(self.detections) < 1 and not (export_mask or export_colored_mask):
+            # there are no detections for this frame, leave early
+            if not (export_mask or export_colored_mask): 
+                # if not mask export return the same input-frame
+                return frame
+            else:
+                # if mask export, return empty mask
+                return np.full((frame.shape[0], frame.shape[1], 3), 0, dtype=np.uint8)
 
         # convert to float, since the mask needs to be in range [0, 1] and in float
         frame = np.float64(frame)


### PR DESCRIPTION
If there are no detections in an image, the input frame is returned. My understanding is that this is an unwanted behaviour if the parameters 'export_mask' or 'export_colored_mask' are set. In this case the return of a mask (in this case empty --> black image) is expected. 