### PR TITLE
Performance improvement: process blurring of batches in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,6 @@ optional arguments:
         Quality of the resulting video. higher = better. Conversion to crf:
         ⌊(1-q/10)*51⌋.
 
-    -f [0, 5]  (Default: 0)
-    --frame_memory [0, 5]
-        Blur objects in the last x frames too.
-
     -fe [0, 99]  (Default: 5)
     --feather_edges [0, 99]
         Feather edges of blurred areas, removes sharp edges on blur-mask.
@@ -234,8 +230,8 @@ With the transition to a custom YOLOv5 detector, the original targets for the to
 - release standalone executable
 
 Implemented post processing steps:
-- a "frame memory": plate and face positions from the last n frames are also blurred → useful for static plates/faces
-- enlarging of blurred regions → useful in combination with frame memory - most single missed frames can be captured this way, unless very quick movement is happening
+- ~~a "frame memory": plate and face positions from the last n frames are also blurred → useful for static plates/faces~~ removed because frames are processed in parallel now
+- enlarging of blurred regions 
 
 
 <!-- CONTRIBUTING -->

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ There's now also a fairly simple CLI to blur a video:
 ```
 usage: cli.py -i INPUT_PATH -o OUTPUT_PATH [-w WEIGHTS] [-s [1, 1024]]
               [-b [1, 99]] [-if [144, 2160]] [-t [0.0, 1.0]] [-r [0.0, 2.0]]
-              [-q [1.0, 10.0]] [-f [0, 5]] [-fe [0, 99]] [-nf] [-m] [-mc] [-h]
+              [-q [1.0, 10.0]] [-fe [0, 99]] [-nf] [-m] [-mc] [-h]
 
 This tool allows you to automatically censor faces and number plates on
 dashcam footage.
@@ -107,7 +107,8 @@ dashcam footage.
 required arguments:
     -i INPUT_PATH
     --input_path INPUT_PATH
-        Input video file path. Pass a folder name for batch processing all files in the folder.
+        Input video file path. Pass a folder name for batch processing all
+        files in the folder.
 
     -o OUTPUT_PATH
     --output_path OUTPUT_PATH
@@ -185,8 +186,7 @@ optional arguments (advanced):
         lower confidence are discarded.
         Channels; Red: Faces, Green: Numberplates.
         Hint: turn off --feather_edges by setting -fe=0 and turn --quality to
-        10, a --frame_memory=0 is also recommended for this setting.
-
+        10
 ```
 For now, there are no default values and all parameters have to be provided (in order). There's also no progress bar yet, but there should be an error/success message as soon as blurring is finished/has encountered any issues.
 
@@ -231,7 +231,7 @@ With the transition to a custom YOLOv5 detector, the original targets for the to
 
 Implemented post processing steps:
 - ~~a "frame memory": plate and face positions from the last n frames are also blurred → useful for static plates/faces~~ removed because frames are processed in parallel now
-- enlarging of blurred regions 
+- enlarging of blurred regions
 
 
 <!-- CONTRIBUTING -->

--- a/dashcamcleaner/cli.py
+++ b/dashcamcleaner/cli.py
@@ -185,16 +185,6 @@ Not recommended for CPU usage.""",
         default=10,
     )
     optional.add_argument(
-        "-f",
-        "--frame_memory",
-        required=False,
-        help="Blur objects in the last x frames too.",
-        type=int,
-        metavar="[0, 5]",
-        choices=range(5 + 1),
-        default=0,
-    )
-    optional.add_argument(
         "-fe",
         "--feather_edges",
         required=False,
@@ -230,7 +220,7 @@ The value represents the confidence of the detector.
 Lower values mean less confidence, brighter colors mean more confidence.
 If the --threshold setting is larger than 0 then detections with a lower confidence are discarded.
 Channels; Red: Faces, Green: Numberplates.
-Hint: turn off --feather_edges by setting -fe=0 and turn --quality to 10, a --frame_memory=0 is also recommended for this setting.""",
+Hint: turn off --feather_edges by setting -fe=0 and turn --quality to 10""",
         default=False,
     )
     optional.add_argument(

--- a/dashcamcleaner/main.py
+++ b/dashcamcleaner/main.py
@@ -97,7 +97,6 @@ class MainWindow(QMainWindow):
             "input_path": self.ui.line_source.text(),
             "output_path": self.ui.line_target.text(),
             "blur_size": self.ui.spin_blur.value(),
-            "frame_memory": self.ui.spin_memory.value(),
             "threshold": self.ui.double_spin_threshold.value(),
             "roi_multi": self.ui.double_spin_roimulti.value(),
             "inference_size": inference_size,

--- a/dashcamcleaner/main.py
+++ b/dashcamcleaner/main.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 import inspect
-import os
 import sys
-from glob import glob
 from pathlib import Path
 
 from PySide6.QtCore import QSettings

--- a/dashcamcleaner/src/blurrer.py
+++ b/dashcamcleaner/src/blurrer.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
-from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
 from shutil import which
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import cv2
 import imageio
@@ -163,16 +163,21 @@ def is_installed(name):
     return which(name) is not None
 
 
-def blur_helper(args: List):
+def blur_helper(args: Tuple[cv2.Mat, List[Detection], Dict]):
     """
     Free helper function with a single parameter that can be called in a ProcessPoolExecutor
     :param args: List of apply_blur parameters
     :return: Blurred frame
     """
-    return apply_blur(*args)
+
+    frame: cv2.Mat
+    new_detections: List[Detection]
+    parameters: Dict
+    frame, new_detections, parameters = args
+    return apply_blur(frame, new_detections, parameters)
 
 
-def apply_blur(frame: np.array, new_detections: List[Detection], parameters: Dict):
+def apply_blur(frame: cv2.Mat, new_detections: List[Detection], parameters: Dict):
     """
     Apply Gaussian blur to regions of interests
     :param frame: input image
@@ -187,7 +192,7 @@ def apply_blur(frame: np.array, new_detections: List[Detection], parameters: Dic
     export_mask = parameters["export_mask"]
     export_colored_mask = parameters["export_colored_mask"]
 
-    detections = []
+    detections: List[Detection] = []
     for detection in new_detections:
         if no_faces and detection.kind == "face":
             continue

--- a/dashcamcleaner/src/mainwindow.ui
+++ b/dashcamcleaner/src/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>842</width>
+    <width>685</width>
     <height>263</height>
    </rect>
   </property>
@@ -66,16 +66,6 @@
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Frame memory</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QSpinBox" name="spin_memory"/>
-      </item>
       <item>
        <widget class="QLabel" name="label_3">
         <property name="text">
@@ -223,7 +213,10 @@
          <number>1</number>
         </property>
         <property name="maximum">
-         <number>200</number>
+         <number>256</number>
+        </property>
+        <property name="value">
+         <number>16</number>
         </property>
        </widget>
       </item>

--- a/dashcamcleaner/src/qt_wrapper.py
+++ b/dashcamcleaner/src/qt_wrapper.py
@@ -1,15 +1,15 @@
 import os
 import subprocess
-from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
 from shutil import which
 from timeit import default_timer as timer
 
 import cv2
 import imageio
-from PySide6.QtCore import QThread, Signal
 from more_itertools import chunked
-from src.blurrer import VideoBlurrer, apply_blur, blur_helper
+from PySide6.QtCore import QThread, Signal
+from src.blurrer import VideoBlurrer, blur_helper
 
 
 class qtVideoBlurWrapper(QThread, VideoBlurrer):

--- a/dashcamcleaner/src/qt_wrapper.py
+++ b/dashcamcleaner/src/qt_wrapper.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor
 from shutil import which
 from timeit import default_timer as timer
 
@@ -8,7 +9,7 @@ import cv2
 import imageio
 from PySide6.QtCore import QThread, Signal
 from more_itertools import chunked
-from src.blurrer import VideoBlurrer
+from src.blurrer import VideoBlurrer, apply_blur, blur_helper
 
 
 class qtVideoBlurWrapper(QThread, VideoBlurrer):
@@ -57,6 +58,7 @@ class qtVideoBlurWrapper(QThread, VideoBlurrer):
             duration = meta["duration"]
             length = int(duration * fps)
             audio_present = "audio_codec" in meta
+            blur_executor = ProcessPoolExecutor()
 
             # save the video to a file
             with imageio.get_writer(
@@ -70,11 +72,12 @@ class qtVideoBlurWrapper(QThread, VideoBlurrer):
                 for frame_batch in chunked(reader, batch_size):
                     frame_buffer = [cv2.cvtColor(frame_read, cv2.COLOR_BGR2RGB) for frame_read in frame_batch]
                     new_detections = self.detect_identifiable_information(frame_buffer)
-                    for frame, detections in zip(frame_buffer, new_detections):
-                        frame_blurred = self.apply_blur(frame, detections)
+                    args = [[frame, detections, self.parameters] for frame, detections in
+                            zip(frame_buffer, new_detections)]
+                    for frame_blurred in blur_executor.map(blur_helper, args):
                         frame_blurred_rgb = cv2.cvtColor(frame_blurred, cv2.COLOR_BGR2RGB)
                         writer.append_data(frame_blurred_rgb)
-                        current_frame += 1
+                    current_frame += batch_size
                     self.updateProgress.emit(current_frame)
 
         # copy over audio stream from original video to edited video

--- a/dashcamcleaner/src/ui_mainwindow.py
+++ b/dashcamcleaner/src/ui_mainwindow.py
@@ -4,7 +4,7 @@
 ################################################################################
 ## Form generated from reading UI file 'mainwindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.2.3
+## Created by: Qt User Interface Compiler version 6.3.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -25,7 +25,7 @@ class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
-        MainWindow.resize(842, 263)
+        MainWindow.resize(685, 263)
         self.centralwidget = QWidget(MainWindow)
         self.centralwidget.setObjectName(u"centralwidget")
         self.verticalLayout = QVBoxLayout(self.centralwidget)
@@ -73,16 +73,6 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
-        self.label_2 = QLabel(self.centralwidget)
-        self.label_2.setObjectName(u"label_2")
-
-        self.horizontalLayout_3.addWidget(self.label_2)
-
-        self.spin_memory = QSpinBox(self.centralwidget)
-        self.spin_memory.setObjectName(u"spin_memory")
-
-        self.horizontalLayout_3.addWidget(self.spin_memory)
-
         self.label_3 = QLabel(self.centralwidget)
         self.label_3.setObjectName(u"label_3")
 
@@ -179,7 +169,8 @@ class Ui_MainWindow(object):
         self.spin_batch = QSpinBox(self.centralwidget)
         self.spin_batch.setObjectName(u"spin_batch")
         self.spin_batch.setMinimum(1)
-        self.spin_batch.setMaximum(200)
+        self.spin_batch.setMaximum(256)
+        self.spin_batch.setValue(16)
 
         self.horizontalLayout_4.addWidget(self.spin_batch)
 
@@ -243,7 +234,6 @@ class Ui_MainWindow(object):
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"DashcamCleaner", None))
         self.button_source.setText(QCoreApplication.translate("MainWindow", u"Select video", None))
         self.button_target.setText(QCoreApplication.translate("MainWindow", u"Select target", None))
-        self.label_2.setText(QCoreApplication.translate("MainWindow", u"Frame memory", None))
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"Blur size", None))
         self.label_9.setText(QCoreApplication.translate("MainWindow", u"Feather edges", None))
         self.label_5.setText(QCoreApplication.translate("MainWindow", u"Detection threshold:", None))


### PR DESCRIPTION
Analysing the callgraph of the tool shows that ~40% of execution time is spent blurring identified detections:

More detections (and the usage of the beautiful feather_edges option) can yet increase the amount of time spent on blurring. Also, faster inference times (especially when using GPUs, which wasn't done in this profiling run) would increase this share further, to ~75% in some cases.
![callgraph](https://user-images.githubusercontent.com/2624591/210100785-77d79517-6652-4623-a4cc-18a82a6da5e7.png)
With that in mind, a (simple) improvement is to process the blurring of identified regions in parallel, on a per-batch level. This comes with a few side effects:

- the frame memory function has to die - [that's okay, it was only somewhat useful for stationary scenes anyway](https://i.kym-cdn.com/entries/icons/original/000/029/024/Screen_Shot_2019-03-22_at_2.47.05_PM.jpg)
- processing time decreases dramatically, on my machine (M1 Max) by ~35% for a short test video with few detections and with 720p_small_mosaic weights

With this step done, the "limiting factors" remaining are:
- batches are only processed once all frames are (sequentially) added
- the 4 stages (reading frames, detecting objects, blurring frames and writing frames) only happen sequentially

However, each of these steps feature parallelisation in their own scope. For the most part (and depending on your hardware), this change should lead to significantly higher resource utilisation.