### PR TITLE
fix(blurrer.py): threshold not defined error

### DIFF
--- a/dashcamcleaner/src/blurrer.py
+++ b/dashcamcleaner/src/blurrer.py
@@ -67,7 +67,7 @@ class VideoBlurrer:
         blur_workers = min(self.parameters["blur_workers"], mp.cpu_count(), batch_size)
 
         # customize detector
-        self.detector.conf = threshold
+        self.detector.conf = self.parameters["threshold"]
 
         # open video file
         with imageio.get_reader(input_path) as reader:


### PR DESCRIPTION
When running the published docker image or a locally built image the application does not start due to this error:
```
 ➜ docker run -it --rm -v "$PWD/input:/input" -v "$PWD/output:/output" dashcamcleaner --weights 1080p_medium_v8

Start blurring video: /input/combo.MP4
Blurring parameter: {'input_path': PosixPath('/input/combo.MP4'), 'output_path': PosixPath('/output/combo.MP4'), 'weights': '1080p_medium_v8', 'blur_workers': 2, 'batch_size': 2, 'blur_size': 9, 'threshold': 0.4, 'roi_multi': 1.0, 'quality': 10, 'feather_edges': 5, 'no_faces': False, 'export_mask': False, 'export_colored_mask': False}
Using CPU.
Worker created
Traceback (most recent call last):
  File "/app/cli.py", line 256, in <module>
    cli.start_blurring()
  File "/app/cli.py", line 57, in start_blurring
    self.start_blurring_file()
  File "/app/cli.py", line 78, in start_blurring_file
    blurrer.blur_video()
  File "/app/src/blurrer.py", line 70, in blur_video
    self.detector.conf = threshold
NameError: name 'threshold' is not defined
```

Same error when specifying a threshold:
```
 ➜ docker run -it --rm -v "$PWD/input:/input:/input" -v "$PWD/output:/output" dashcamcleaner --weights 1080p_medium_v8 --threshold 0.4

Start blurring video: /input/combo.MP4
Blurring parameter: {'input_path': PosixPath('/input/combo.MP4'), 'output_path': PosixPath('/output/combo.MP4'), 'weights': '1080p_medium_v8', 'blur_workers': 2, 'batch_size': 2, 'blur_size': 9, 'threshold': 0.4, 'roi_multi': 1.0, 'quality': 10, 'feather_edges': 5, 'no_faces': False, 'export_mask': False, 'export_colored_mask': False}
Using CPU.
Worker created
Traceback (most recent call last):
  File "/app/cli.py", line 256, in <module>
    cli.start_blurring()
  File "/app/cli.py", line 57, in start_blurring
    self.start_blurring_file()
  File "/app/cli.py", line 78, in start_blurring_file
    blurrer.blur_video()
  File "/app/src/blurrer.py", line 70, in blur_video
    self.detector.conf = threshold
NameError: name 'threshold' is not defined
```

This PR fix the undefined variable :)